### PR TITLE
Update common.php changing getCSVSchema to convert diacritics in field names instead of removing them

### DIFF
--- a/php/common.php
+++ b/php/common.php
@@ -11981,6 +11981,10 @@ function getCSVSchema($file,$params=array()){
 				$bomchecked=1;
 			}
 			if(count($fields)==0){
+				// Using iconv to convert CSV header row to ASCII with TRANSLIT//IGNORE will remove/transliterate diacritics. There is no need to detect $from_encoding because the internal method fopen_utf8 (used above) yields UTF-8 data. NOTE: Locale must be set using setlocale (already done above) for consistent results across platforms/installs/versions, otherwise transliteration will replace characters with "?".
+				$lineparts=implode($params['-separator'], $lineparts);
+				$lineparts=iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $lineparts); // NOTE: Warning: This will break the delimited string if the separator is not an ASCII character!
+				$lineparts=explode($params['-separator'], $lineparts);
 				$fields=$lineparts;
 				//remove spaces and weird chars
 				foreach($fields as $x=>$field){


### PR DESCRIPTION
Change getCSVSchema to transliterate characters with diacritics in field names to ASCII alphabetical characters before they are removed by the preg_replace that removes everything but alphanumerics and underscores.